### PR TITLE
Socint 41 save inbound case

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>ons.sdc.int.common</groupId>
     <artifactId>common</artifactId>
     <!-- change this to the version of ALL common libs to be used by this build -->
-    <version>1.0.19-SNAPSHOT</version>
+    <version>1.0.18</version>
   </parent>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>ons.sdc.int.common</groupId>
     <artifactId>common</artifactId>
     <!-- change this to the version of ALL common libs to be used by this build -->
-    <version>1.0.18-SNAPSHOT</version>
+    <version>1.0.19-SNAPSHOT</version>
   </parent>
 
   <scm>

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/CCSvcBeanMapper.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/CCSvcBeanMapper.java
@@ -1,5 +1,8 @@
 package uk.gov.ons.ctp.integration.contactcentresvc;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.MappingContext;
 import ma.glasnost.orika.converter.BidirectionalConverter;
@@ -35,6 +38,7 @@ public class CCSvcBeanMapper extends ConfigurableMapper {
     converterFactory.registerConverter("regionConverter", new RegionConverter());
     converterFactory.registerConverter(new StringToUUIDConverter());
     converterFactory.registerConverter(new StringToUPRNConverter());
+    converterFactory.registerConverter(new UtcOffsetDateTimeConverter());
 
     factory
         .classMap(CaseContainerDTO.class, CaseDTO.class)
@@ -91,7 +95,7 @@ public class CCSvcBeanMapper extends ConfigurableMapper {
     factory.classMap(CaseContainerDTO.class, AddressCompact.class).byDefault().register();
   }
 
-  private class RegionConverter extends BidirectionalConverter<String, String> {
+  static class RegionConverter extends BidirectionalConverter<String, String> {
     public String convertTo(String src, Type<String> dstType, MappingContext context) {
       return convert(src);
     }
@@ -102,6 +106,20 @@ public class CCSvcBeanMapper extends ConfigurableMapper {
 
     private String convert(String src) {
       return StringUtils.isEmpty(src) ? src : src.substring(0, 1).toUpperCase();
+    }
+  }
+
+  static class UtcOffsetDateTimeConverter extends BidirectionalConverter<Date, OffsetDateTime> {
+    @Override
+    public OffsetDateTime convertTo(
+        Date source, Type<OffsetDateTime> destinationType, MappingContext mappingContext) {
+      return source.toInstant().atOffset(ZoneOffset.UTC);
+    }
+
+    @Override
+    public Date convertFrom(
+        OffsetDateTime source, Type<Date> destinationType, MappingContext mappingContext) {
+      return new Date(source.toInstant().toEpochMilli());
     }
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiver.java
@@ -7,7 +7,6 @@ import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
-import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.event.model.CaseEvent;
 import uk.gov.ons.ctp.common.event.model.CollectionCase;
 import uk.gov.ons.ctp.integration.contactcentresvc.CCSvcBeanMapper;
@@ -30,16 +29,15 @@ public class CaseEventReceiver {
    * Message end point for events from Response Management.
    *
    * @param caseEvent CaseEvent message from Response Management
-   * @throws CTPException something went wrong
    */
   @ServiceActivator(inputChannel = "acceptCaseEvent")
-  public void acceptCaseEvent(CaseEvent caseEvent) throws CTPException {
+  public void acceptCaseEvent(CaseEvent caseEvent) {
 
     CollectionCase collectionCase = caseEvent.getPayload().getCollectionCase();
     String caseTransactionId = caseEvent.getEvent().getTransactionId();
 
     log.info(
-        "Entering acceptCaseEvent",
+        "Entering acceptCaseEvent {}, {}",
         kv("transactionId", caseTransactionId),
         kv("caseId", collectionCase.getId()));
 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiver.java
@@ -43,6 +43,11 @@ public class CaseEventReceiver {
 
     Case caze = map(collectionCase);
     caseRepo.save(caze);
+
+    log.info(
+        "Successful saved Case to database {}, {}",
+        kv("transactionId", caseTransactionId),
+        kv("caseId", collectionCase.getId()));
   }
 
   private Case map(CollectionCase collectionCase) {

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiver.java
@@ -1,11 +1,12 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.event;
 
 import static uk.gov.ons.ctp.common.log.ScopedStructuredArguments.kv;
+
+import lombok.extern.slf4j.Slf4j;
+import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
-import lombok.extern.slf4j.Slf4j;
-import ma.glasnost.orika.MapperFacade;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.event.model.CaseEvent;
 import uk.gov.ons.ctp.common.event.model.CollectionCase;

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiver.java
@@ -1,23 +1,29 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.event;
 
 import static uk.gov.ons.ctp.common.log.ScopedStructuredArguments.kv;
-
-import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
+import lombok.extern.slf4j.Slf4j;
+import ma.glasnost.orika.MapperFacade;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.event.model.CaseEvent;
 import uk.gov.ons.ctp.common.event.model.CollectionCase;
+import uk.gov.ons.ctp.integration.contactcentresvc.CCSvcBeanMapper;
+import uk.gov.ons.ctp.integration.contactcentresvc.model.Case;
+import uk.gov.ons.ctp.integration.contactcentresvc.repository.db.CaseRepository;
 
 /**
  * Service implementation responsible for receipt of Case Events. See Spring Integration flow for
  * details of inbound queue.
  */
 @Slf4j
-@Data
 @MessageEndpoint
 public class CaseEventReceiver {
+
+  @Autowired CaseRepository caseRepo;
+
+  private MapperFacade mapper = new CCSvcBeanMapper();
 
   /**
    * Message end point for events from Response Management.
@@ -36,6 +42,12 @@ public class CaseEventReceiver {
         kv("transactionId", caseTransactionId),
         kv("caseId", collectionCase.getId()));
 
-    // TODO processing code
+    Case caze = map(collectionCase);
+    caseRepo.save(caze);
+  }
+
+  private Case map(CollectionCase collectionCase) {
+    Case caze = mapper.map(collectionCase, Case.class);
+    return caze;
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/Case.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/Case.java
@@ -1,12 +1,20 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.model;
 
+import java.time.OffsetDateTime;
 import java.util.UUID;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @Entity
 @Table(name = "caze")
 public class Case {
@@ -14,6 +22,19 @@ public class Case {
   @Id private UUID caseId;
 
   private Long caseRef;
-  private String uprn;
   private String caseType;
+  private String survey;
+  private UUID collectionExerciseId;
+  private String actionableFrom;
+  private boolean handDelivery;
+  private boolean addressInvalid;
+  private Integer ceExpectedCapacity;
+
+  @Embedded
+  private CaseContact contact;
+
+  @Embedded
+  private CaseAddress address;
+
+  private OffsetDateTime createdDateTime;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/Case.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/Case.java
@@ -11,12 +11,20 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import uk.gov.ons.ctp.common.domain.CaseType;
 import uk.gov.ons.ctp.common.time.DateTimeUtil;
 
-@Data
+/**
+ * Representation of Case entity from database table.
+ *
+ * <p>Implementation note: avoid Lombok Data annotation, since generated toString, equals and
+ * hashcode are dangerous in combination with Entity annotation.
+ */
+@Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/Case.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/Case.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "caze")
 public class Case {
 
-  @Id private UUID caseId;
+  @Id private UUID id;
 
   private Long caseRef;
   private String caseType;

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/Case.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/Case.java
@@ -1,15 +1,20 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.ons.ctp.common.domain.CaseType;
+import uk.gov.ons.ctp.common.time.DateTimeUtil;
 
 @Data
 @Builder
@@ -22,7 +27,10 @@ public class Case {
   @Id private UUID id;
 
   private Long caseRef;
-  private String caseType;
+
+  @Enumerated(EnumType.STRING)
+  private CaseType caseType;
+
   private String survey;
   private UUID collectionExerciseId;
   private String actionableFrom;
@@ -34,5 +42,6 @@ public class Case {
 
   @Embedded private CaseAddress address;
 
+  @JsonFormat(pattern = DateTimeUtil.DATE_FORMAT_IN_JSON, timezone = "UTC")
   private OffsetDateTime createdDateTime;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/Case.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/Case.java
@@ -30,11 +30,9 @@ public class Case {
   private boolean addressInvalid;
   private Integer ceExpectedCapacity;
 
-  @Embedded
-  private CaseContact contact;
+  @Embedded private CaseContact contact;
 
-  @Embedded
-  private CaseAddress address;
+  @Embedded private CaseAddress address;
 
   private OffsetDateTime createdDateTime;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/CaseAddress.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/CaseAddress.java
@@ -1,11 +1,15 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.model;
 
 import javax.persistence.Embeddable;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @Embeddable
 public class CaseAddress {
   private String uprn;

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/CaseAddress.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/CaseAddress.java
@@ -1,0 +1,28 @@
+package uk.gov.ons.ctp.integration.contactcentresvc.model;
+
+import javax.persistence.Embeddable;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@Embeddable
+public class CaseAddress {
+  private String uprn;
+
+  private String addressLine1;
+  private String addressLine2;
+  private String addressLine3;
+  private String townName;
+  private String postcode;
+
+  private String region; // E, W or N
+  private String estabType;
+  private String organisationName;
+
+  private String latitude;
+  private String longitude;
+  private String estabUprn;
+  private String addressType;
+  private String addressLevel;
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/CaseContact.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/CaseContact.java
@@ -1,0 +1,27 @@
+package uk.gov.ons.ctp.integration.contactcentresvc.model;
+
+import javax.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.ons.ctp.common.event.model.Contact;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Embeddable
+public class CaseContact {
+  private String title;
+  private String forename;
+  private String surname;
+  private String telNo;
+
+  public CaseContact(Contact eventContact) {
+    title = eventContact.getTitle();
+    forename = eventContact.getForename();
+    surname = eventContact.getSurname();
+    telNo = eventContact.getTelNo();
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/CaseContact.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/CaseContact.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import uk.gov.ons.ctp.common.event.model.Contact;
 
 @Data
 @Builder
@@ -17,11 +16,4 @@ public class CaseContact {
   private String forename;
   private String surname;
   private String telNo;
-
-  public CaseContact(Contact eventContact) {
-    title = eventContact.getTitle();
-    forename = eventContact.getForename();
-    surname = eventContact.getSurname();
-    telNo = eventContact.getTelNo();
-  }
 }

--- a/src/main/resources/db/migration/V2__CaseTable.sql
+++ b/src/main/resources/db/migration/V2__CaseTable.sql
@@ -1,0 +1,44 @@
+
+DROP TABLE caze;
+
+CREATE TABLE caze (
+    case_id UUID NOT NULL,
+    case_ref INT8,
+    case_type VARCHAR(255),
+    survey VARCHAR(255) NOT NULL,
+    collection_exercise_id UUID,
+    actionable_from VARCHAR(255),
+    hand_delivery BOOLEAN DEFAULT false,
+    address_invalid BOOLEAN DEFAULT false NOT NULL,
+	ce_expected_capacity INT4,
+
+	-- contact
+	title VARCHAR(255),
+  	forename VARCHAR(255),
+  	surname VARCHAR(255),
+  	tel_no VARCHAR(255),
+
+  	-- address
+    uprn VARCHAR(255),
+    address_line1 VARCHAR(255),
+    address_line2 VARCHAR(255),
+    address_line3 VARCHAR(255),
+    town_name VARCHAR(255),
+    postcode VARCHAR(255),
+	region VARCHAR(255),
+	estab_type VARCHAR(255),
+	organisation_name VARCHAR(255),
+	latitude VARCHAR(255),
+    longitude VARCHAR(255),
+    estab_uprn VARCHAR(255),
+    address_type VARCHAR(255),
+	address_level VARCHAR(255),
+    --
+    created_date_time TIMESTAMP WITH TIME ZONE,
+
+    PRIMARY KEY (case_id)
+);
+
+CREATE INDEX caze_case_ref_idx ON caze (case_ref);
+CREATE INDEX caze_uprn_idx ON caze (uprn);
+

--- a/src/main/resources/db/migration/V2__CaseTable.sql
+++ b/src/main/resources/db/migration/V2__CaseTable.sql
@@ -13,29 +13,29 @@ CREATE TABLE caze (
     actionable_from VARCHAR(255),
     hand_delivery BOOLEAN DEFAULT false,
     address_invalid BOOLEAN DEFAULT false NOT NULL,
-	ce_expected_capacity INT4,
+    ce_expected_capacity INT4,
 
-	-- contact
-	title VARCHAR(255),
-  	forename VARCHAR(255),
-  	surname VARCHAR(255),
-  	tel_no VARCHAR(255),
+    -- contact
+    title VARCHAR(255),
+    forename VARCHAR(255),
+    surname VARCHAR(255),
+    tel_no VARCHAR(255),
 
-  	-- address
+    -- address
     uprn VARCHAR(255),
     address_line1 VARCHAR(255),
     address_line2 VARCHAR(255),
     address_line3 VARCHAR(255),
     town_name VARCHAR(255),
     postcode VARCHAR(255),
-	region VARCHAR(255),
-	estab_type VARCHAR(255),
-	organisation_name VARCHAR(255),
-	latitude VARCHAR(255),
+    region VARCHAR(255),
+    estab_type VARCHAR(255),
+    organisation_name VARCHAR(255),
+    latitude VARCHAR(255),
     longitude VARCHAR(255),
     estab_uprn VARCHAR(255),
     address_type VARCHAR(255),
-	address_level VARCHAR(255),
+    address_level VARCHAR(255),
     --
     created_date_time TIMESTAMP WITH TIME ZONE,
 

--- a/src/main/resources/db/migration/V2__CaseTable.sql
+++ b/src/main/resources/db/migration/V2__CaseTable.sql
@@ -2,7 +2,7 @@
 DROP TABLE caze;
 
 CREATE TABLE caze (
-    case_id UUID NOT NULL,
+    id UUID NOT NULL,
     case_ref INT8,
     case_type VARCHAR(255),
     survey VARCHAR(255) NOT NULL,
@@ -36,7 +36,7 @@ CREATE TABLE caze (
     --
     created_date_time TIMESTAMP WITH TIME ZONE,
 
-    PRIMARY KEY (case_id)
+    PRIMARY KEY (id)
 );
 
 CREATE INDEX caze_case_ref_idx ON caze (case_ref);

--- a/src/main/resources/db/migration/V2__CaseTable.sql
+++ b/src/main/resources/db/migration/V2__CaseTable.sql
@@ -1,10 +1,13 @@
 
 DROP TABLE caze;
 
+CREATE TYPE CASE_TYPE_ENUM AS ENUM('HH', 'HI', 'CE', 'SPG');
+CREATE CAST (VARCHAR AS CASE_TYPE_ENUM) WITH INOUT AS IMPLICIT;
+
 CREATE TABLE caze (
     id UUID NOT NULL,
     case_ref INT8,
-    case_type VARCHAR(255),
+    case_type CASE_TYPE_ENUM,
     survey VARCHAR(255) NOT NULL,
     collection_exercise_id UUID,
     actionable_from VARCHAR(255),

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiverTest.java
@@ -2,6 +2,7 @@ package uk.gov.ons.ctp.integration.contactcentresvc.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -20,14 +21,11 @@ import uk.gov.ons.ctp.integration.contactcentresvc.repository.db.CaseRepository;
 @ExtendWith(MockitoExtension.class)
 public class CaseEventReceiverTest {
 
-  @Mock
-  private CaseRepository repo;
+  @Mock private CaseRepository repo;
 
-  @InjectMocks
-  private CaseEventReceiver target;
+  @InjectMocks private CaseEventReceiver target;
 
-  @Captor
-  private ArgumentCaptor<Case> caseCaptor;
+  @Captor private ArgumentCaptor<Case> caseCaptor;
 
   @Test
   public void dummy() {}
@@ -44,7 +42,6 @@ public class CaseEventReceiverTest {
     Case caze = caseCaptor.getValue();
     CaseContact contact = caze.getContact();
     assertEquals(expectedContact(ccase.getContact()), contact);
-
   }
 
   private CaseContact expectedContact(Contact contact) {
@@ -55,5 +52,4 @@ public class CaseEventReceiverTest {
         .telNo(contact.getTelNo())
         .build();
   }
-
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiverTest.java
@@ -1,0 +1,59 @@
+package uk.gov.ons.ctp.integration.contactcentresvc.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.ons.ctp.common.FixtureHelper;
+import uk.gov.ons.ctp.common.event.model.CaseEvent;
+import uk.gov.ons.ctp.common.event.model.CollectionCase;
+import uk.gov.ons.ctp.common.event.model.Contact;
+import uk.gov.ons.ctp.integration.contactcentresvc.model.Case;
+import uk.gov.ons.ctp.integration.contactcentresvc.model.CaseContact;
+import uk.gov.ons.ctp.integration.contactcentresvc.repository.db.CaseRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class CaseEventReceiverTest {
+
+  @Mock
+  private CaseRepository repo;
+
+  @InjectMocks
+  private CaseEventReceiver target;
+
+  @Captor
+  private ArgumentCaptor<Case> caseCaptor;
+
+  @Test
+  public void dummy() {}
+
+  @Test
+  public void shouldReceiveEvent() throws Exception {
+    CaseEvent caseEvent = FixtureHelper.loadPackageFixtures(CaseEvent[].class).get(0);
+    target.acceptCaseEvent(caseEvent);
+
+    verify(repo).save(caseCaptor.capture());
+
+    CollectionCase ccase = caseEvent.getPayload().getCollectionCase();
+
+    Case caze = caseCaptor.getValue();
+    CaseContact contact = caze.getContact();
+    assertEquals(expectedContact(ccase.getContact()), contact);
+
+  }
+
+  private CaseContact expectedContact(Contact contact) {
+    return CaseContact.builder()
+        .forename(contact.getForename())
+        .surname(contact.getSurname())
+        .title(contact.getTitle())
+        .telNo(contact.getTelNo())
+        .build();
+  }
+
+}

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiverTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.ons.ctp.common.FixtureHelper;
+import uk.gov.ons.ctp.common.domain.CaseType;
 import uk.gov.ons.ctp.common.event.model.Address;
 import uk.gov.ons.ctp.common.event.model.CaseEvent;
 import uk.gov.ons.ctp.common.event.model.CollectionCase;
@@ -44,18 +44,20 @@ public class CaseEventReceiverTest {
     CollectionCase ccase = caseEvent.getPayload().getCollectionCase();
 
     Case caze = caseCaptor.getValue();
+    verifyMappedCase(caze, ccase);
+  }
+
+  private void verifyMappedCase(Case caze, CollectionCase ccase) {
     CaseContact contact = caze.getContact();
     CaseAddress address = caze.getAddress();
     assertEquals(expectedContact(ccase.getContact()), contact);
     assertEquals(expectedAddress(ccase.getAddress()), address);
 
-    assertEquals(
-        OffsetDateTime.parse("2020-06-08T07:28:45.113Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
-        caze.getCreatedDateTime());
+    assertEquals(OffsetDateTime.parse("2020-06-08T07:28:45.113Z"), caze.getCreatedDateTime());
 
     assertEquals(UUID.fromString("0000089e-c6ef-46cb-9f09-b4def5a6d2d1"), caze.getId());
     assertEquals(Long.valueOf(ccase.getCaseRef()), caze.getCaseRef());
-    assertEquals(ccase.getCaseType(), caze.getCaseType());
+    assertEquals(CaseType.valueOf(ccase.getCaseType()), caze.getCaseType());
     assertEquals(ccase.getSurvey(), caze.getSurvey());
     assertEquals(UUID.fromString(ccase.getCollectionExerciseId()), caze.getCollectionExerciseId());
     assertEquals(ccase.getActionableFrom(), caze.getActionableFrom());

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiverTest.java
@@ -1,8 +1,13 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -11,10 +16,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.ons.ctp.common.FixtureHelper;
+import uk.gov.ons.ctp.common.event.model.Address;
 import uk.gov.ons.ctp.common.event.model.CaseEvent;
 import uk.gov.ons.ctp.common.event.model.CollectionCase;
 import uk.gov.ons.ctp.common.event.model.Contact;
 import uk.gov.ons.ctp.integration.contactcentresvc.model.Case;
+import uk.gov.ons.ctp.integration.contactcentresvc.model.CaseAddress;
 import uk.gov.ons.ctp.integration.contactcentresvc.model.CaseContact;
 import uk.gov.ons.ctp.integration.contactcentresvc.repository.db.CaseRepository;
 
@@ -28,10 +35,7 @@ public class CaseEventReceiverTest {
   @Captor private ArgumentCaptor<Case> caseCaptor;
 
   @Test
-  public void dummy() {}
-
-  @Test
-  public void shouldReceiveEvent() throws Exception {
+  public void shouldReceiveEvent() {
     CaseEvent caseEvent = FixtureHelper.loadPackageFixtures(CaseEvent[].class).get(0);
     target.acceptCaseEvent(caseEvent);
 
@@ -41,7 +45,23 @@ public class CaseEventReceiverTest {
 
     Case caze = caseCaptor.getValue();
     CaseContact contact = caze.getContact();
+    CaseAddress address = caze.getAddress();
     assertEquals(expectedContact(ccase.getContact()), contact);
+    assertEquals(expectedAddress(ccase.getAddress()), address);
+
+    assertEquals(
+        OffsetDateTime.parse("2020-06-08T07:28:45.113Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+        caze.getCreatedDateTime());
+
+    assertEquals(UUID.fromString("0000089e-c6ef-46cb-9f09-b4def5a6d2d1"), caze.getId());
+    assertEquals(Long.valueOf(ccase.getCaseRef()), caze.getCaseRef());
+    assertEquals(ccase.getCaseType(), caze.getCaseType());
+    assertEquals(ccase.getSurvey(), caze.getSurvey());
+    assertEquals(UUID.fromString(ccase.getCollectionExerciseId()), caze.getCollectionExerciseId());
+    assertEquals(ccase.getActionableFrom(), caze.getActionableFrom());
+    assertTrue(caze.isHandDelivery());
+    assertFalse(caze.isAddressInvalid());
+    assertEquals(ccase.getCeExpectedCapacity(), caze.getCeExpectedCapacity());
   }
 
   private CaseContact expectedContact(Contact contact) {
@@ -50,6 +70,25 @@ public class CaseEventReceiverTest {
         .surname(contact.getSurname())
         .title(contact.getTitle())
         .telNo(contact.getTelNo())
+        .build();
+  }
+
+  private CaseAddress expectedAddress(Address addr) {
+    return CaseAddress.builder()
+        .uprn(addr.getUprn())
+        .addressLine1(addr.getAddressLine1())
+        .addressLine2(addr.getAddressLine2())
+        .addressLine3(addr.getAddressLine3())
+        .townName(addr.getTownName())
+        .postcode(addr.getPostcode())
+        .region(addr.getRegion())
+        .estabType(addr.getEstabType())
+        .organisationName(addr.getOrganisationName())
+        .latitude(addr.getLatitude())
+        .longitude(addr.getLongitude())
+        .estabUprn(addr.getEstabUprn())
+        .addressType(addr.getAddressType())
+        .addressLevel(addr.getAddressLevel())
         .build();
   }
 }

--- a/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/event/PackageFixture.CaseEvent.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/event/PackageFixture.CaseEvent.json
@@ -1,0 +1,43 @@
+{
+  "event" : {
+    "type" : "CASE_UPDATED",
+    "source" : "CONTACT_CENTRE_API",
+    "channel" : "CC",
+    "dateTime" : "2020-06-08T07:28:45.117Z",
+    "transactionId" : "c45de4dc-3c3b-11e9-b210-d663bd873d93"
+  },
+  "payload" : {
+    "collectionCase" : {
+      "id" : "900000000",
+      "caseRef" : "10000000010",
+      "caseType" : "HH",
+      "survey" : "Census",
+      "collectionExerciseId" : "n66de4dc-3c3b-11e9-b210-d663bd873d93",
+      "address" : {
+        "addressLine1" : "1 main street",
+        "addressLine2" : "upper upperingham",
+        "addressLine3" : "",
+        "townName" : "upton",
+        "postcode" : "UP103UP",
+        "region" : "E",
+        "uprn" : "XXXXXXXXXXXXX",
+        "latitude" : "50.863849",
+        "longitude" : "-1.229710",
+        "estabUprn" : null,
+        "addressType" : "CE",
+        "addressLevel" : "E",
+        "estabType" : "XXX"
+      },
+      "contact" : {
+        "title" : "Ms",
+        "forename" : "jo",
+        "surname" : "smith",
+        "telNo" : "+447890000000"
+      },
+      "actionableFrom" : "2011-08-12T20:17:46.384Z",
+      "handDelivery" : true,
+      "addressInvalid" : false,
+      "createdDateTime" : "2020-06-08T07:28:45.113Z"
+    }
+  }
+}

--- a/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/event/PackageFixture.CaseEvent.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/event/PackageFixture.CaseEvent.json
@@ -8,7 +8,7 @@
   },
   "payload" : {
     "collectionCase" : {
-      "id" : "900000000",
+      "id" : "0000089e-c6ef-46cb-9f09-b4def5a6d2d1",
       "caseRef" : "10000000010",
       "caseType" : "HH",
       "survey" : "Census",

--- a/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/event/PackageFixture.CaseEvent.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/event/PackageFixture.CaseEvent.json
@@ -12,7 +12,7 @@
       "caseRef" : "10000000010",
       "caseType" : "HH",
       "survey" : "Census",
-      "collectionExerciseId" : "n66de4dc-3c3b-11e9-b210-d663bd873d93",
+      "collectionExerciseId" : "c66de4dc-3c3b-11e9-b210-d663bd873d93",
       "address" : {
         "addressLine1" : "1 main street",
         "addressLine2" : "upper upperingham",


### PR DESCRIPTION

The case table has been updated to include all elements received from inbound case event,
and those case events are now saved into the posgreSQL (Cloud SQL) database table, using standard Spring JPA repository save function.

JIRA LINK: https://collaborate2.ons.gov.uk/jira/browse/SOCINT-41