### PR TITLE
SOCINT-211 add transactional annotation for all receiver logic

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CollectionExerciseEventReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CollectionExerciseEventReceiver.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ctp.common.event.model.CollectionExerciseUpdateEvent;
 import uk.gov.ons.ctp.integration.contactcentresvc.model.CollectionExercise;
 import uk.gov.ons.ctp.integration.contactcentresvc.repository.db.CollectionExerciseRepository;
@@ -29,6 +30,7 @@ public class CollectionExerciseEventReceiver {
    * @param event event from RM
    */
   @ServiceActivator(inputChannel = "acceptCollectionExerciseEvent")
+  @Transactional
   public void acceptEvent(CollectionExerciseUpdateEvent event) {
 
     var payload = event.getPayload().getCollectionExerciseUpdate();

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/event/SurveyEventReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/event/SurveyEventReceiver.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ctp.common.event.model.SurveyUpdate;
 import uk.gov.ons.ctp.common.event.model.SurveyUpdateEvent;
 import uk.gov.ons.ctp.integration.contactcentresvc.model.Survey;
@@ -28,6 +29,7 @@ public class SurveyEventReceiver {
    * @param event event from RM.
    */
   @ServiceActivator(inputChannel = "acceptSurveyUpdateEvent")
+  @Transactional
   public void acceptEvent(SurveyUpdateEvent event) {
 
     SurveyUpdate payload = event.getPayload().getSurveyUpdate();


### PR DESCRIPTION

Ensure all receivers have transactional scope. The lack of this annotation may have contributed to intermittent cucumber failures.