### PR TITLE
SOCINT-292 cohort is a string not an integer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>ons.sdc.int.common</groupId>
     <artifactId>common</artifactId>
     <!-- change this to the version of ALL common libs to be used by this build -->
-    <version>1.0.62</version>
+    <version>1.0.63</version>
   </parent>
 
   <scm>

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/Case.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/model/Case.java
@@ -46,7 +46,7 @@ public class Case {
 
   private String questionnaire;
   private String sampleUnitRef;
-  private Integer cohort;
+  private String cohort;
 
   @Embedded private CaseAddress address;
   @Embedded private CaseContact contact;

--- a/src/main/resources/db/migration/V10__CohortTypeChange.sql
+++ b/src/main/resources/db/migration/V10__CohortTypeChange.sql
@@ -1,0 +1,2 @@
+ALTER TABLE collection_case ALTER COLUMN cohort TYPE TEXT;
+ALTER TABLE case_response ALTER COLUMN cohort TYPE TEXT;

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/event/CaseEventReceiverIT.java
@@ -59,7 +59,7 @@ public class CaseEventReceiverIT extends PostgresTestBase {
     assertNotNull(caze);
     assertEquals("10000000017", caze.getCaseRef());
     assertEquals("AB1 2ZX", caze.getAddress().getPostcode());
-    assertEquals(7, caze.getCohort());
+    assertEquals("CC3", caze.getCohort());
   }
 
   /**

--- a/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/CCSvcBeanMapperTest.Case.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/CCSvcBeanMapperTest.Case.json
@@ -8,7 +8,7 @@
   "refusalReceived": null,
   "questionnaire": "dummy_9wbthzvgj6",
   "sampleUnitRef": "dummy_6zfd5iq9pg",
-  "cohort": "7",
+  "cohort": "CC3",
   "address": {
     "uprn": "334999999999",
     "addressLine1": "Napier House",

--- a/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/CCSvcBeanMapperTest.CaseUpdate.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/CCSvcBeanMapperTest.CaseUpdate.json
@@ -15,7 +15,7 @@
     "uprn": "123456789",
     "questionnaire": "dummy_9wbthzvgj6",
     "sampleUnitRef": "dummy_6zfd5iq9pg",
-    "cohort": "7",
+    "cohort": "CC3",
     "gor9d": "dummy_99n62dhi40",
     "laCode": "dummy_p468dsuyo5",
     "uprnLatitude": "52.35064053950229",

--- a/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/event/PackageFixture.CaseEvent.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/event/PackageFixture.CaseEvent.json
@@ -27,7 +27,7 @@
         "uprn": "123456789",
         "questionnaire": "dummy_9wbthzvgj6",
         "sampleUnitRef": "dummy_6zfd5iq9pg",
-        "cohort": "7",
+        "cohort": "CC3",
         "gor9d": "dummy_99n62dhi40",
         "laCode": "dummy_p468dsuyo5",
         "uprnLatitude": "52.35064053950229",

--- a/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/PackageFixture.Case.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/PackageFixture.Case.json
@@ -8,7 +8,7 @@
   "refusalReceived": null,
   "questionnaire": "dummy_9wbthzvgj6",
   "sampleUnitRef": "dummy_6zfd5iq9pg",
-  "cohort": "7",
+  "cohort": "CC3",
   "address": {
     "uprn": "334999999999",
     "addressLine1": "Napier House",


### PR DESCRIPTION
cohort is a string not an integer.

Changes:
- flyway to change a couple of tables where `cohort` was an integer; notably the `collection_case` table
- `cohort` change type in `Case` entity
- json test changes.

See JIRA LINK: https://collaborate2.ons.gov.uk/jira/browse/SOCINT-292