### PR TITLE
Socint 278 remove junit4 introduced by testcontainers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,10 @@
       </exclusions>
     </dependency>
 
+    <!-- Junit4 mocks allow us to remove the unwanted junit4 transitive dependency
+         introduced by testcontainers in a safe way. It is a minimal library of
+         about 4 or 5 dummy interfaces. This will no longer be needed when
+         testcontainers moves to version 2 -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit4-mock</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,18 @@
       <artifactId>testcontainers</artifactId>
       <version>${testcontainers.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit4-mock</artifactId>
+      <version>2.5.0.Final</version>
     </dependency>
 
     <dependency>

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/repository/db/UserRoleRepositoryIT.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/repository/db/UserRoleRepositoryIT.java
@@ -1,9 +1,9 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.repository.db;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION

Junit 4 unwanted dependency has already caused confusion and lost time in the team. This fixes that issue.